### PR TITLE
Add project.urls and description to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "tstrings-backport"
-version = "0.1.2"
-description = "Add your description here"
+version = "0.1.0"
+description = "Backport of t-strings (PEP 750)"
 readme = "README.md"
 authors = [
     { name = "Stefane Fermigier", email = "sf@abilian.com" }
@@ -9,13 +9,14 @@ authors = [
 requires-python = ">=3.9"
 dependencies = []
 
-[project.urls]
-Repository = "https://github.com/abilian/tstrings-backport"
-Homepage = "https://github.com/abilian/tstrings-backport"
-
 [build-system]
 requires = ["uv_build>=0.8.4,<0.9.0"]
 build-backend = "uv_build"
+
+[project.urls]
+Documentation = "https://github.com/abilian/tstrings-backport"
+Issues = "https://github.com/abilian/tstrings-backport/issues"
+Source = "https://github.com/abilian/tstrings-backport"
 
 [tool.uv.build-backend]
 module-name = "tstrings"


### PR DESCRIPTION
I found this package via https://discuss.python.org/t/appetite-for-a-backport-of-strings-template-for-python-3-14/100997/3 and thought I could help improve it.

Specifically, I want the [pypi page](https://pypi.org/project/tstrings-backport/) to have a link to this repo.