### PR TITLE
chore: run any python version using makefile, use that as entrypoint in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        # # KEEP THIS IN SYNC WITH THE Makefile
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
@@ -18,14 +19,10 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install uv
       run: pip install uv
-    - name: Install dependencies
-      run: uv sync --group dev
     - name: Run tests
-      run: uv run pytest
+      run: make test
     - name: Run linting
-      run: uv run ruff check .
-    - name: Check formatting
-      run: uv run ruff format . --check
+      run: make lint
 
   build:
     runs-on: ubuntu-latest
@@ -39,4 +36,4 @@ jobs:
     - name: Install uv
       run: pip install uv
     - name: Build package
-      run: uv build
+      run: make build

--- a/Makefile
+++ b/Makefile
@@ -1,34 +1,72 @@
 .PHONY: all test build format check lint clean
 
+# This allows you to run tests/linting/etc. in different python versions, eg:
+# `make test` runs in existing python version
+# `make test python=3.10` runs in python 3.10
+# `make test python=all` runs in all supported python versions
+# KEEP THIS IN SYNC WITH .github/workflows/ci.yml
+PYTHON_VERSIONS = 3.9 3.10 3.11 3.12 3.13 3.14
+python ?=
+
 all:
-	ruff check .
 	@make test
 	@make check
 
 check: lint
 
 lint:
-	ruff check .
-	ruff format . --check
-	ty check src
-	pyrefly check src
-	mypy src
+ifeq ($(python),all)
+	$(foreach ver,$(PYTHON_VERSIONS),uv run --python $(ver) ruff check . &&) true
+	$(foreach ver,$(PYTHON_VERSIONS),uv run --python $(ver) ruff format . --check &&) true
+	$(foreach ver,$(PYTHON_VERSIONS),uv run --python $(ver) ty check src &&) true
+	$(foreach ver,$(PYTHON_VERSIONS),uv run --python $(ver) pyrefly check src &&) true
+	$(foreach ver,$(PYTHON_VERSIONS),uv run --python $(ver) mypy src &&) true
+else ifdef python
+	uv run --python $(python) ruff check .
+	uv run --python $(python) ruff format . --check
+	uv run --python $(python) ty check src
+	uv run --python $(python) pyrefly check src
+	uv run --python $(python) mypy src
+else
+	uv run ruff check .
+	uv run ruff format . --check
+	uv run ty check src
+	uv run pyrefly check src
+	uv run mypy src
+endif
 
 format:
-	ruff format .
-	ruff check . --fix
-	ruff format .
+ifeq ($(python),all)
+	$(foreach ver,$(PYTHON_VERSIONS),uv run --python $(ver) ruff format . &&) true
+	$(foreach ver,$(PYTHON_VERSIONS),uv run --python $(ver) ruff check . --fix &&) true
+	$(foreach ver,$(PYTHON_VERSIONS),uv run --python $(ver) ruff format . &&) true
+else ifdef python
+	uv run --python $(python) ruff format .
+	uv run --python $(python) ruff check . --fix
+	uv run --python $(python) ruff format .
+else
+	uv run ruff format .
+	uv run ruff check . --fix
+	uv run ruff format .
+endif
 
 test:
-	uv run --python 3.9 pytest
-	uv run --python 3.10 pytest
-	uv run --python 3.11 pytest
-	uv run --python 3.12 pytest
-	uv run --python 3.13 pytest
-	uv run --python 3.14 pytest
+ifeq ($(python),all)
+	$(foreach ver,$(PYTHON_VERSIONS),uv run --python $(ver) pytest &&) true
+else ifdef python
+	uv run --python $(python) pytest
+else
+	uv run pytest
+endif
 
 build: clean
+ifeq ($(python),all)
+	$(foreach ver,$(PYTHON_VERSIONS),uv build --python $(ver) &&) true
+else ifdef python
+	uv build --python $(python)
+else
 	uv build
+endif
 
 clean:
 	rm -rf .pytest_cache .ruff_cache dist build __pycache__ .mypy_cache .coverage htmlcov .coverage.* *.egg-info

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 authors = [
     { name = "Stefane Fermigier", email = "sf@abilian.com" }
 ]
+# KEEP THIS IN SYNC WITH THE MAKEFILE
 requires-python = ">=3.9"
 dependencies = []
 

--- a/src/tstrings/__init__.py
+++ b/src/tstrings/__init__.py
@@ -42,7 +42,7 @@ _INTERPOLATION_RE = re.compile(
 if sys.version_info >= (3, 10):
     dataclass_extra_args = {"slots": True}
 else:
-    dataclass_extra_args = {}
+    dataclass_extra_args: dict[str, bool] = {}
 
 
 @dataclass(frozen=True, eq=False, **dataclass_extra_args)


### PR DESCRIPTION
This should ensure that ALL tests get run in CI, and that it is easier to reproduce the exact CI run locally.

It also expands CI to test on python 3.14

It also adds one small type annotation so this passes mypy on python 3.9