### PR TITLE
feat: support `Template("Answer: ", Interpolation(5, "ans"))` flavor of init

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,9 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Support `Template("Answer: ", Interpolation(5, "ans"))` flavor of `Template.__init__()`. Before, we only supported keyword-only, eg `Template(strings=("Answer: ", ""), interpolations=(Interpolation(5, "ans"), ))`. This brings us in line with the vanilla API for creating string.templatelib.Template. See https://github.com/abilian/tstrings-backport/issues/4.
+- `py.typed` marker for PEP 561 compliance (thanks @NickCrews)
 - GitHub CI configuration based on nox
 - SourceHut CI integration
-- `py.typed` marker for PEP 561 compliance (thanks @NickCrews)
 - Test for bogus format specifier error handling (thanks @NickCrews)
 - `assert_templates_equal()` test helper function (thanks @NickCrews)
 - Nox configuration for testing against multiple Python versions

--- a/src/tstrings/__init__.py
+++ b/src/tstrings/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 import sys
+from collections.abc import Iterable
 from dataclasses import dataclass
 from itertools import zip_longest
 from typing import TYPE_CHECKING, Literal, NoReturn, cast
@@ -66,24 +67,92 @@ class Interpolation:
         return id(self)
 
 
-@dataclass(frozen=True, eq=False, **dataclass_extra_args)
 class Template:
     """Emulates the string.templatelib.Template class from PEP 750.
 
     Represents a parsed t-string literal.
     """
 
-    strings: tuple[str, ...]
-    """
-    A non-empty tuple of the string parts of the template,
-    with N+1 items, where N is the number of interpolations
-    in the template.
-    """
-    interpolations: tuple[Interpolation, ...]
-    """
-    A tuple of the interpolation parts of the template.
-    This will be an empty tuple if there are no interpolations.
-    """
+    def __init__(
+        self,
+        *vargs: str | Interpolation,
+        strings: Iterable[str] = (),
+        interpolations: Iterable[Interpolation] = (),
+    ) -> None:
+        """Initializes a Template instance.
+
+        Args:
+            *vargs: Positional arguments that are either strings or Interpolations.
+                If provided, `strings` and `interpolations` must be empty.
+            strings: An iterable of string parts of the template.
+            interpolations: An iterable of Interpolation parts of the template.
+
+        Raises:
+            TypeError: If both positional and keyword arguments are provided.
+            ValueError: If the number of strings is not one more than the number
+                of interpolations.
+
+        Example:
+            >>> from tstrings import Interpolation, Template
+            >>> interp = Interpolation(value=42, expression="answer")
+
+            You can create a Template using keyword arguments:
+
+            >>> template = Template(
+            ...     strings=("The answer is ", "."), interpolations=(interp,)
+            ... )
+            >>> template.strings
+            ('The answer is ', '.')
+            >>> template.interpolations
+            (Interpolation(value=42, expression='answer', conversion=None, format_spec=''),)
+
+            Or using positional arguments:
+
+            >>> template2 = Template("The", " answer", " is ", interp, ".")
+            >>> template2.strings
+            ('The answer is ', '.')
+            >>> template2.interpolations
+            (Interpolation(value=42, expression='answer', conversion=None, format_spec=''),)
+        """  # noqa: E501
+        if vargs:
+            if strings or interpolations:
+                raise TypeError("Cannot mix positional and keyword arguments.")
+            parsed_strings: list[str] = []
+            parsed_interpolations: list[Interpolation] = []
+            current_string = ""
+            for arg in vargs:
+                if isinstance(arg, str):
+                    current_string += arg
+                elif isinstance(arg, Interpolation):
+                    parsed_strings.append(current_string)
+                    current_string = ""
+                    parsed_interpolations.append(arg)
+            parsed_strings.append(current_string)
+            self._strings = tuple(parsed_strings)
+            self._interpolations = tuple(parsed_interpolations)
+        else:
+            self._strings = tuple(strings) if strings else ("",)
+            self._interpolations = tuple(interpolations)
+        if len(self._strings) != len(self._interpolations) + 1:
+            raise ValueError(
+                "Number of strings must be one more than number of interpolations."
+            )
+
+    @property
+    def strings(self) -> tuple[str, ...]:
+        """A non-empty tuple of the string parts of the template.
+
+        There will always be one more string part than interpolation.
+        """
+        return self._strings
+
+    @property
+    def interpolations(self) -> tuple[Interpolation, ...]:
+        """A tuple of the interpolation parts of the template.
+
+        This will be an empty tuple if there are no interpolations.
+        """
+        return self._interpolations
 
     @property
     def values(self) -> tuple[object, ...]:
@@ -104,7 +173,7 @@ class Template:
             if i:
                 yield i
 
-    def __add__(self, other: Template) -> Template:
+    def __add__(self, other: Template, /) -> Template:
         """Adds two templates together."""
         # lazy duck-typing isinstance check
         if not hasattr(other, "strings") or not hasattr(other, "interpolations"):
@@ -116,7 +185,7 @@ class Template:
             interpolations=self.interpolations + other.interpolations,
         )
 
-    def __eq__(self, value: object) -> bool:
+    def __eq__(self, value: object, /) -> bool:
         """Template and Interpolation instances compare with object identity (is)."""
         return self is value
 
@@ -127,6 +196,10 @@ class Template:
     def __str__(self) -> NoReturn:
         """Explicitly disallowed."""
         raise TypeError("Template instances cannot be converted to strings directly.")
+
+    def __repr__(self) -> str:
+        """Debug representation of the Template instance."""
+        return f"{self.__class__.__name__}(strings={self.strings!r}, interpolations={self.interpolations!r})"  # noqa: E501
 
 
 def t(template_string: str, /) -> Template:

--- a/src/tstrings/__init__.py
+++ b/src/tstrings/__init__.py
@@ -7,7 +7,7 @@ import sys
 from collections.abc import Iterable
 from dataclasses import dataclass
 from itertools import zip_longest
-from typing import TYPE_CHECKING, Literal, NoReturn, cast
+from typing import TYPE_CHECKING, Literal, NoReturn, Protocol, cast, runtime_checkable
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -46,6 +46,16 @@ else:
     dataclass_extra_args = {}
 
 
+@runtime_checkable
+class IntoInterpolation(Protocol):
+    """Protocol for objects that can be converted into Interpolation instances."""
+
+    value: object
+    expression: str
+    conversion: Literal["a", "r", "s"] | None
+    format_spec: str
+
+
 @dataclass(frozen=True, eq=False, **dataclass_extra_args)
 class Interpolation:
     """Emulates the string.templatelib.Interpolation class from PEP 750.
@@ -67,6 +77,20 @@ class Interpolation:
         return id(self)
 
 
+def coerce_interpolation(item: IntoInterpolation) -> Interpolation:
+    try:
+        return Interpolation(
+            value=item.value,
+            expression=item.expression,
+            conversion=item.conversion,
+            format_spec=item.format_spec,
+        )
+    except AttributeError as e:
+        raise TypeError(
+            f"Expected an Interpolation or IntoInterpolation, got {type(item)!r}"
+        ) from e
+
+
 class Template:
     """Emulates the string.templatelib.Template class from PEP 750.
 
@@ -75,9 +99,9 @@ class Template:
 
     def __init__(
         self,
-        *vargs: str | Interpolation,
+        *vargs: str | IntoInterpolation,
         strings: Iterable[str] = (),
-        interpolations: Iterable[Interpolation] = (),
+        interpolations: Iterable[IntoInterpolation] = (),
     ) -> None:
         """Initializes a Template instance.
 
@@ -94,7 +118,7 @@ class Template:
 
         Example:
             >>> from tstrings import Interpolation, Template
-            >>> interp = Interpolation(value=42, expression="answer")
+            >>> interp = Interpolation(42, "answer")
 
             You can create a Template using keyword arguments:
 
@@ -114,6 +138,7 @@ class Template:
             >>> template2.interpolations
             (Interpolation(value=42, expression='answer', conversion=None, format_spec=''),)
         """  # noqa: E501
+
         if vargs:
             if strings or interpolations:
                 raise TypeError("Cannot mix positional and keyword arguments.")
@@ -123,16 +148,19 @@ class Template:
             for arg in vargs:
                 if isinstance(arg, str):
                     current_string += arg
-                elif isinstance(arg, Interpolation):
+                else:
                     parsed_strings.append(current_string)
                     current_string = ""
-                    parsed_interpolations.append(arg)
+                    coerced = coerce_interpolation(arg)
+                    parsed_interpolations.append(coerced)
             parsed_strings.append(current_string)
             self._strings = tuple(parsed_strings)
             self._interpolations = tuple(parsed_interpolations)
         else:
             self._strings = tuple(strings) if strings else ("",)
-            self._interpolations = tuple(interpolations)
+            self._interpolations = tuple(
+                coerce_interpolation(i) for i in interpolations
+            )
         if len(self._strings) != len(self._interpolations) + 1:
             raise ValueError(
                 "Number of strings must be one more than number of interpolations."

--- a/src/tstrings/__init__.py
+++ b/src/tstrings/__init__.py
@@ -48,12 +48,23 @@ else:
 
 @runtime_checkable
 class IntoInterpolation(Protocol):
-    """Protocol for objects that can be converted into Interpolation instances."""
+    """Protocol for objects that have all the attributes of an Interpolation.
 
-    value: object
-    expression: str
-    conversion: Literal["a", "r", "s"] | None
-    format_spec: str
+    These are
+    - value: object
+    - expression: str
+    - conversion: Literal["a", "r", "s"] | None
+    - format_spec: str
+    """
+
+    @property
+    def value(self) -> object: ...
+    @property
+    def expression(self) -> str: ...
+    @property
+    def conversion(self) -> Literal["a", "r", "s"] | None: ...
+    @property
+    def format_spec(self) -> str: ...
 
 
 @dataclass(frozen=True, eq=False, **dataclass_extra_args)

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -252,6 +252,37 @@ def test_generator_coercion():
     assert_templates_equal(template, expected)
 
 
+def test_interpolation_coercion():
+    """Things that look like Interpolations are coerced into Interpolations."""
+
+    class MyInterpolation:
+        def __init__(self, value, expression):
+            self.value = value
+            self.expression = expression
+            self.conversion = None
+            self.format_spec = ""
+
+    expected = Template(
+        strings=("hello ", "!"), interpolations=(Interpolation(5, "five"),)
+    )
+    template = Template("hello ", MyInterpolation(5, "five"), "!")
+    assert isinstance(template.interpolations[0], Interpolation)
+    assert_templates_equal(template, expected)
+
+    template = Template(
+        strings=("hello ", "!"), interpolations=(MyInterpolation(5, "five"),)
+    )
+    assert isinstance(template.interpolations[0], Interpolation)
+    assert_templates_equal(template, expected)
+
+
+def test_non_string_interpolations_errors():
+    with pytest.raises(TypeError):
+        Template("hello ", 5, "!")  # ty:ignore[invalid-argument-type]
+    with pytest.raises(TypeError):
+        Template(strings=("hello ", "!"), interpolations=(5, "five"))  # ty:ignore[invalid-argument-type]
+
+
 @pytest.mark.parametrize(
     ("strings,interpolations"),
     [

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -238,6 +238,90 @@ def test_syntax_error_in_expression_raises_error():
         t("This is invalid: {1 +}")
 
 
+def test_generator_coercion():
+    """Ensures that Template can be initialized with a generator."""
+    template = Template(
+        strings=(s for s in ("part1", "part2")),
+        interpolations=(i for i in (Interpolation(5, "five"),)),
+    )
+    assert isinstance(template.strings, tuple)
+    assert isinstance(template.interpolations, tuple)
+    expected = Template(
+        strings=("part1", "part2"), interpolations=(Interpolation(5, "five"),)
+    )
+    assert_templates_equal(template, expected)
+
+
+@pytest.mark.parametrize(
+    ("strings,interpolations"),
+    [
+        pytest.param(("only one string",), (Interpolation(5, "five"),), id="both 1"),
+        pytest.param(
+            ("string1", "string2"),
+            (Interpolation(5, "five"), Interpolation(10, "ten")),
+            id="both 2",
+        ),
+        pytest.param(("str1", "str2", "str3"), (), id="strings only"),
+    ],
+)
+def test_mismatched_lens_errors(strings, interpolations):
+    with pytest.raises(ValueError) as exc_info:
+        Template(strings=strings, interpolations=interpolations)
+    assert str(exc_info.value) == (
+        "Number of strings must be one more than number of interpolations."
+    )
+
+
+def test_both_varargs_and_kwargs_errors():
+    with pytest.raises(TypeError):
+        Template("hello", strings=("hello",), interpolations=())
+    with pytest.raises(TypeError):
+        Template(
+            "hello",
+            strings=("hello", "there"),
+            interpolations=(Interpolation(5, "five"),),
+        )
+
+
+def test_init_empty():
+    """Ensures that Template can be initialized with no values"""
+    template = Template()
+    assert template.strings == ("",)
+    assert template.interpolations == ()
+
+
+def test_init_single_string():
+    """Ensures that Template can be initialized with a single string"""
+    template = Template("single string")
+    assert template.strings == ("single string",)
+    assert template.interpolations == ()
+
+
+def test_init_adjecent_strings_merged():
+    """Ensures that adjacent strings are merged"""
+    template = Template("string1", "string2")
+    assert template.strings == ("string1string2",)
+    assert template.interpolations == ()
+
+
+def test_init_leading_interpolations():
+    template = Template(Interpolation(5, "five"), "string1", "string2")
+    expected = Template(
+        strings=("", "string1string2"),
+        interpolations=(Interpolation(5, "five"),),
+    )
+    assert_templates_equal(template, expected)
+
+
+def test_init_only_interpolations():
+    template = Template(Interpolation(5, "five"), Interpolation(10, "ten"))
+    expected = Template(
+        strings=("", "", ""),
+        interpolations=(Interpolation(5, "five"), Interpolation(10, "ten")),
+    )
+    assert_templates_equal(template, expected)
+
+
 def test_interpolation_repr():
     """Ensures that the repr of an Interpolation instance is as expected."""
     interp = Interpolation("value", "expr", "r", ".2f")


### PR DESCRIPTION
Fixes https://github.com/abilian/tstrings-backport/issues/4

Before, we only support the keywords flavor. Now we also support the varargs flavor. You can only use one at a time. This moves us away from a dataclass implementation, but that didn't actually require many changes.